### PR TITLE
Migrations to be excluded from pep8

### DIFF
--- a/{{cookiecutter.package_name}}/setup.cfg
+++ b/{{cookiecutter.package_name}}/setup.cfg
@@ -3,4 +3,4 @@ addopts = --doctest-modules --verbose --ignore=ve/ {{cookiecutter.package_name}}
 
 [flake8]
 ignore = F403
-exclude = ve,docs
+exclude = ve,docs,migrations,settings.py


### PR DESCRIPTION
As per @smn: "the migrations should automatically be excluded from pep8 by the cookiecutter template".
"the only valid pep8 complaints there are the tests, views & models
everything else (migrations mostly) should be ignored by pep8 and that is something that can be configured in the `setup.cfg` file in the cookie cutter template"
